### PR TITLE
Fix render callback

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -63,63 +63,66 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		$post_types = get_post_types(  [ 'public' => true ] );
+		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
 		ob_start();
 
 		?>
-        <div class="<?php echo $class_name; ?>">
+		<div class="<?php echo $class_name; ?>">
 			<h2>Post Counts</h2>
 			<ul>
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
-                $post_type_object = get_post_type_object( $post_type_slug  );
-                $post_count = count(
-                    get_posts(
+				$post_type_object = get_post_type_object( $post_type_slug );
+				$post_count       = count(
+					get_posts(
 						[
-							'post_type' => $post_type_slug,
+							'post_type'      => $post_type_slug,
 							'posts_per_page' => -1,
 						]
 					)
-                );
+				);
 
 				?>
-				<li><?php echo 'There are ' . $post_count . ' ' .
-					  $post_type_object->labels->name . '.'; ?></li>
-			<?php endforeach;	?>
+				<li> <?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.'; ?> </li>
+			<?php endforeach; ?>
 			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
 
 			<?php
-			$query = new WP_Query(  array(
-				'post_type' => ['post', 'page'],
-				'post_status' => 'any',
-				'date_query' => array(
-					array(
-						'hour'      => 9,
-						'compare'   => '>=',
-					),
-					array(
-						'hour' => 17,
-						'compare'=> '<=',
-					),
-				),
-                'tag'  => 'foo',
-                'category_name'  => 'baz',
-				  'post__not_in' => [ get_the_ID() ],
-				  'meta_value' => 'Accepted',
-			));
+			$query = new WP_Query(
+				[
+					'post_type'     => [ 'post', 'page' ],
+					'post_status'   => 'any',
+					'date_query'    => [
+						[
+							'hour'    => 9,
+							'compare' => '>=',
+						],
+						[
+							'hour'    => 17,
+							'compare' => '<=',
+						],
+					],
+					'tag'           => 'foo',
+					'category_name' => 'baz',
+					'post__not_in'  => [ get_the_ID() ],
+					'meta_value'    => 'Accepted',
+				]
+			);
 
 			if ( $query->found_posts ) :
 				?>
-				 <h2>Any 5 posts with the tag of foo and the category of baz</h2>
-                <ul>
-                <?php
+				<h2>Any 5 posts with the tag of foo and the category of baz</h2>
+				<ul>
 
-                 foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-                    ?><li><?php echo $post->post_title ?></li><?php
+				<?php
+				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
+					?>
+					<li><?php echo $post->post_title; ?></li>
+					<?php
 				endforeach;
 			endif;
-		 	?>
+			?>
 			</ul>
 		</div>
 		<?php


### PR DESCRIPTION
Some improvements for performance and security:

- Removed `get_post_type_object()` by adding second parameter 'objects' to `get_post_types()`.
- Added translation and escaping.
- Used `wp_count_posts()` for better performance.
- Removed `page` from `post_type` array for WP_Query because tag and category is not available for pages.
- Removed `post__not_in` and array_slice, and added `posts_per_page` for better performance.
- Added `no_found_rows`, `update_post_meta_cache`, and `update_post_term_cache` to WP_Query for better performance.
- Made found posts count dynamic. ( Any %d posts with the tag of foo ... )
- Fixed ending `</ul>` misplacement issue.
- PHP CS fix.
- Added `className` attribute check.
- Replaced `$_GET['post_id']` with `get_the_ID()`